### PR TITLE
World compendiums should not allow invalid characters

### DIFF
--- a/scripts/token-attacher.js
+++ b/scripts/token-attacher.js
@@ -2078,7 +2078,7 @@ import {libWrapper} from './shim.js';
 			if(options.hasOwnProperty("module-label")) label = "("+options["module-label"] + ")" + label;
 			 
 			const parentMap = {null:{value:null}};
-			let worldCompendium = await CompendiumCollection.createCompendium({label:label, name: name, type:"Actor"});
+			let worldCompendium = await CompendiumCollection.createCompendium({label:label, name: name.slugify({strict: true}), type:"Actor"});
 			let creates = [];
 			actors.forEach(async actor => {
 				creates.push({type: game.system.documentTypes.Actor[0], img:actor.img, name:actor.name, token: actor.token, flags: actor.flags});


### PR DESCRIPTION
The default foundry UI runs the compendium name through the slugify method, we should do the same.

Prompted by the thread on Baileywiki's Discord https://discord.com/channels/746091041890762852/757057551907946526/928114279050272788