### PR TITLE
Small safety filter

### DIFF
--- a/scripts/token-attacher.js
+++ b/scripts/token-attacher.js
@@ -593,7 +593,7 @@ import {libWrapper} from './shim.js';
 			//Get Entities
 			for (const key in attached) {
 				const layer = canvas.getLayerByEmbeddedName(key);
-				attachedEntities[key] = attached[key].map(id => TokenAttacher.layerGetElement(layer, id));
+				attachedEntities[key] = attached[key].map(id => TokenAttacher.layerGetElement(layer, id)).filter(entity => entity?.document);
 			}
 
 			let updates = {};


### PR DESCRIPTION
I had a bug report for one of my module which included the attached error message. I am not entirly certain what caused the invalid data to show up but this should prevent the error from coming up again.
![image](https://github.com/KayelGee/token-attacher/assets/137942782/61ab4326-3273-4412-b233-97950deb5322)
