### PR TITLE
Coalesce and async on detach as with attach

### DIFF
--- a/scripts/token-attacher.js
+++ b/scripts/token-attacher.js
@@ -1408,23 +1408,23 @@ import {libWrapper} from './shim.js';
 			return await canvas.scene.unsetFlag(moduleName, "attach_base");		
 		}
 
-		static detachElementFromToken(element, target_token, suppressNotification=false){
+		static async detachElementFromToken(element, target_token, suppressNotification=false){
 			const type = element.layer.constructor.documentName;
-			const selected = [element.document._id];
+			const selected = [element.document?._id ?? element._id];
 			
-			if(TokenAttacher.isFirstActiveGM()) TokenAttacher._DetachFromToken(target_token, {type:type, ids:selected}, suppressNotification);
+			if(TokenAttacher.isFirstActiveGM()) return await TokenAttacher._DetachFromToken(target_token, {type:type, ids:selected}, suppressNotification);
 			else game.socket.emit(`module.${moduleName}`, {event: `DetachFromToken`, eventdata: [target_token.document._id, {type:type, ids:selected}, suppressNotification]});
 		}
 
-		static detachElementsFromToken(element_array, target_token, suppressNotification=false){
+		static async detachElementsFromToken(element_array, target_token, suppressNotification=false){
 			let selected = {}
 			for (const element of element_array) {
 				const type = element.layer.constructor.documentName;
 				if(!selected.hasOwnProperty(type)) selected[type] = [];
-				selected[type].push(element.document._id);
+				selected[type].push(element.document?._id ?? element._id);
 			}
 		
-			if(TokenAttacher.isFirstActiveGM()) TokenAttacher._detachElementsFromToken(selected, target_token, suppressNotification);
+			if(TokenAttacher.isFirstActiveGM()) await TokenAttacher._detachElementsFromToken(selected, target_token, suppressNotification);
 			else game.socket.emit(`module.${moduleName}`, {event: `detachElementsFromToken`, eventdata: [selected, target_token.document._id, suppressNotification]});
 		}
 


### PR DESCRIPTION
Tried this macro:
```javascript
const id_scene = 'some_hardcoded_scene_id';

if (canvas.scene.id !== id_scene) {
  throw new Error('This macro really needs you to be on the proper scene...');
  return;
}

const target_id = 'some_hardcoded_target_id';
const target_token = canvas.tokens.get(target_id);

const player_ids = [
  'some_hardcoded_player_id_1',
  'some_hardcoded_player_id_2',
  'some_hardcoded_player_id_3',
];

const token_docs = canvas.tokens.getDocuments();
const tokens = player_ids.map(p => token_docs.find(t => t.actorId === p));

if (tokens.some(t => !t) || !target_token) {
  throw new Error('the way I wrote this macro, I need the hardcoded players all to have tokens on the scene.');
}

await tokenAttacher.attachElementsToToken(tokens, target_token, true);
await target_token.rotate(90); // this number is absolute instead of relative for some reason, which I need to deal with at some point, but it's not important right now.
await tokenAttacher.detachElementsFromToken(tokens, target_token, true);
```

It mostly worked, except the players stayed attached to the target token. It turns out that `attach` isn't quite symmetrical with `detach`. This... seems to fix that? I haven't done much testing, but I wanted to drop this off over here before I move on and forget that I did this.